### PR TITLE
Make `viewPath` in `ViewRenderer` constructor optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #79: Add debug collector for yiisoft/yii-debug (@xepozz)
 - Bug #82: Fixed find for layout file due to compatibility with `yiisoft/view` (@rustamwin)
+- Enh #99: Make `viewPath` in `ViewRenderer` constructor optional (@vjik)
 
 ## 6.0.0 February 16, 2023
 

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\View;
 
+use LogicException;
 use RuntimeException;
 use Throwable;
 use Yiisoft\Aliases\Aliases;
@@ -42,7 +43,7 @@ use function str_replace;
  */
 final class ViewRenderer implements ViewContextInterface
 {
-    private string $viewPath;
+    private ?string $viewPath = null;
     private ?string $name = null;
     private ?string $locale = null;
 
@@ -50,7 +51,7 @@ final class ViewRenderer implements ViewContextInterface
      * @param DataResponseFactoryInterface $responseFactory The data response factory instance.
      * @param Aliases $aliases The aliases instance.
      * @param WebView $view The web view instance.
-     * @param string $viewPath The full path to the directory of views or its alias.
+     * @param string|null $viewPath The full path to the directory of views or its alias.
      * @param string|null $layout The layout name (e.g. "layout/main") to be applied to views.
      * If null, the layout will not be applied.
      * @param object[] $injections The injection instances.
@@ -59,11 +60,11 @@ final class ViewRenderer implements ViewContextInterface
         private DataResponseFactoryInterface $responseFactory,
         private Aliases $aliases,
         private WebView $view,
-        string $viewPath,
+        ?string $viewPath,
         private ?string $layout = null,
         private array $injections = []
     ) {
-        $this->viewPath = rtrim($viewPath, '/');
+        $this->setViewPath($viewPath);
     }
 
     /**
@@ -75,6 +76,10 @@ final class ViewRenderer implements ViewContextInterface
      */
     public function getViewPath(): string
     {
+        if ($this->viewPath === null) {
+            throw new LogicException('The view path is not set.');
+        }
+
         return $this->aliases->get($this->viewPath) . ($this->name ? '/' . $this->name : '');
     }
 
@@ -218,7 +223,7 @@ final class ViewRenderer implements ViewContextInterface
     public function withViewPath(string $viewPath): self
     {
         $new = clone $this;
-        $new->viewPath = rtrim($viewPath, '/');
+        $new->setViewPath($viewPath);
         return $new;
     }
 
@@ -552,5 +557,10 @@ final class ViewRenderer implements ViewContextInterface
     private function getType(mixed $value): string
     {
         return get_debug_type($value);
+    }
+
+    private function setViewPath(?string $path): void
+    {
+        $this->viewPath = $path === null ? null : rtrim($path, '/');
     }
 }

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -60,7 +60,7 @@ final class ViewRenderer implements ViewContextInterface
         private DataResponseFactoryInterface $responseFactory,
         private Aliases $aliases,
         private WebView $view,
-        ?string $viewPath,
+        ?string $viewPath = null,
         private ?string $layout = null,
         private array $injections = []
     ) {

--- a/tests/ViewRendererTest.php
+++ b/tests/ViewRendererTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Yii\View\Tests;
 
 use HttpSoft\Message\ResponseFactory;
 use HttpSoft\Message\StreamFactory;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use RuntimeException;
@@ -464,6 +465,19 @@ EOD;
         $expected = '<html><head><title>LAYOUT</title></head><body></body></html>';
 
         $this->assertEqualStringsIgnoringLineEndings($expected, (string) $response->getBody());
+    }
+
+    public function testWithoutViewPath(): void
+    {
+        $viewRenderer = new ViewRenderer(
+            new DataResponseFactory(new ResponseFactory(), new StreamFactory()),
+            new Aliases(),
+            new WebView(__DIR__, new SimpleEventDispatcher()),
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The view path is not set.');
+        $viewRenderer->getViewPath();
     }
 
     public function testImmutability(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -