### PR TITLE
Resolve default view path from render call location

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ For more information about localization, see at the [localization](https://githu
 ```php
 'yiisoft/yii-view-renderer' => [    
     // The full path to the directory of views or its alias.
-    // If null, relative view paths in `WebViewRenderer::render()` is not available.
+    // If null, relative view paths in `WebViewRenderer::render*()` are resolved from the call location.
     'viewPath' => null, 
     
     // The full path to the layout file to be applied to views.

--- a/config/params.php
+++ b/config/params.php
@@ -7,7 +7,7 @@ use Yiisoft\Yii\View\Renderer\Debug\WebViewCollector;
 return [
     'yiisoft/yii-view-renderer' => [
         // The full path to the directory of views or its alias.
-        // If null, relative view paths in `ViewRenderer::render()` is not available.
+        // If null, relative view paths in `WebViewRenderer::render*()` are resolved from the call location.
         'viewPath' => null,
 
         // The full path to the layout file to be applied to views.

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -11,6 +11,34 @@
         }
     },
     "mutators": {
-        "@default": true
+        "@default": true,
+        "DecrementInteger": {
+            "ignore": [
+                "Yiisoft\\Yii\\View\\Renderer\\ViewRenderer::extractControllerName",
+                "Yiisoft\\Yii\\View\\Renderer\\WebViewRenderer::extractControllerName"
+            ]
+        },
+        "LogicalAnd": {
+            "ignore": [
+                "Yiisoft\\Yii\\View\\Renderer\\ViewRenderer::extractControllerName",
+                "Yiisoft\\Yii\\View\\Renderer\\WebViewRenderer::extractControllerName"
+            ]
+        },
+        "PregMatchRemoveFlags": {
+            "ignore": [
+                "Yiisoft\\Yii\\View\\Renderer\\ViewRenderer::extractControllerName",
+                "Yiisoft\\Yii\\View\\Renderer\\WebViewRenderer::extractControllerName"
+            ]
+        },
+        "ReturnRemoval": {
+            "ignore": [
+                "Yiisoft\\Yii\\View\\Renderer\\ViewRenderer::extractControllerName",
+                "Yiisoft\\Yii\\View\\Renderer\\ViewRenderer::renderPartial",
+                "Yiisoft\\Yii\\View\\Renderer\\ViewRenderer::renderPartialAsString",
+                "Yiisoft\\Yii\\View\\Renderer\\WebViewRenderer::extractControllerName",
+                "Yiisoft\\Yii\\View\\Renderer\\WebViewRenderer::renderPartial",
+                "Yiisoft\\Yii\\View\\Renderer\\WebViewRenderer::renderPartialAsString"
+            ]
+        }
     }
 }

--- a/src/WebViewRenderer.php
+++ b/src/WebViewRenderer.php
@@ -68,7 +68,7 @@ final class WebViewRenderer implements ViewContextInterface
      * @param Aliases $aliases The aliases instance.
      * @param WebView $view The web view instance.
      * @param string|null $viewPath The full path to the directory of views or its alias. If null, relative view paths
-     * in {@see WebViewRenderer::render()} are resolved from the call location.
+     * in `render*()` methods are resolved from the call location.
      * @param string|null $layout The full path to the layout file to be applied to views. If null, the layout will
      * not be applied.
      * @param array $injections The injection instances or class names.
@@ -626,7 +626,7 @@ final class WebViewRenderer implements ViewContextInterface
 
     private function getCallLocationViewPath(): string
     {
-        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10) as $frame) {
             $file = $frame['file'] ?? __FILE__;
 
             if ($file === __FILE__) {
@@ -636,7 +636,7 @@ final class WebViewRenderer implements ViewContextInterface
             return dirname($file);
         }
 
-        throw new RuntimeException('Cannot detect view path.');
+        throw new RuntimeException('Cannot detect view path from call stack. Configure view path explicitly.');
     }
 
     private function getPreparedInjections(): array

--- a/src/WebViewRenderer.php
+++ b/src/WebViewRenderer.php
@@ -626,8 +626,20 @@ final class WebViewRenderer implements ViewContextInterface
 
     private function getCallLocationViewPath(): string
     {
-        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10) as $frame) {
-            $file = $frame['file'] ?? __FILE__;
+        return $this->resolveCallLocationViewPath(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10));
+    }
+
+    /**
+     * @psalm-param list<array{file?: string, ...}> $backtrace
+     */
+    private function resolveCallLocationViewPath(array $backtrace): string
+    {
+        foreach ($backtrace as $frame) {
+            if (!isset($frame['file']) || !is_string($frame['file'])) {
+                continue;
+            }
+
+            $file = $frame['file'];
 
             if ($file === __FILE__) {
                 continue;

--- a/src/WebViewRenderer.php
+++ b/src/WebViewRenderer.php
@@ -26,6 +26,8 @@ use Yiisoft\Yii\View\Renderer\InjectionContainer\StubInjectionContainer;
 
 use function array_key_exists;
 use function array_merge;
+use function debug_backtrace;
+use function dirname;
 use function is_array;
 use function is_int;
 use function is_object;
@@ -36,6 +38,7 @@ use function sprintf;
 use function str_replace;
 
 use const ARRAY_FILTER_USE_BOTH;
+use const DEBUG_BACKTRACE_IGNORE_ARGS;
 
 /**
  * Factory that creates PSR-7 response instances with a content rendered by view.
@@ -65,7 +68,7 @@ final class WebViewRenderer implements ViewContextInterface
      * @param Aliases $aliases The aliases instance.
      * @param WebView $view The web view instance.
      * @param string|null $viewPath The full path to the directory of views or its alias. If null, relative view paths
-     * in {@see WebViewRenderer::render()} are not available.
+     * in {@see WebViewRenderer::render()} are resolved from the call location.
      * @param string|null $layout The full path to the layout file to be applied to views. If null, the layout will
      * not be applied.
      * @param array $injections The injection instances or class names.
@@ -117,19 +120,20 @@ final class WebViewRenderer implements ViewContextInterface
      */
     public function render(string $view, array $parameters = []): ResponseInterface
     {
-        $commonParameters = $this->getCommonParameters();
-        $layoutParameters = $this->getLayoutParameters();
-        $metaTags = $this->getMetaTags();
-        $linkTags = $this->getLinkTags();
+        $renderer = $this->withDefaultViewPath();
+        $commonParameters = $renderer->getCommonParameters();
+        $layoutParameters = $renderer->getLayoutParameters();
+        $metaTags = $renderer->getMetaTags();
+        $linkTags = $renderer->getLinkTags();
 
-        $response = $this->responseFactory
+        $response = $renderer->responseFactory
             ->createResponse()
-            ->withHeader('Content-Type', "$this->contentType; charset=$this->encoding");
+            ->withHeader('Content-Type', "$renderer->contentType; charset=$renderer->encoding");
 
         return new ViewResponse(
             $response,
-            fn(): StreamInterface => $this->streamFactory->createStream(
-                $this->renderProxy(
+            fn(): StreamInterface => $renderer->streamFactory->createStream(
+                $renderer->renderProxy(
                     $view,
                     $parameters,
                     $commonParameters,
@@ -180,13 +184,15 @@ final class WebViewRenderer implements ViewContextInterface
      */
     public function renderAsString(string $view, array $parameters = []): string
     {
-        return $this->renderProxy(
+        $renderer = $this->withDefaultViewPath();
+
+        return $renderer->renderProxy(
             $view,
             $parameters,
-            $this->getCommonParameters(),
-            $this->getLayoutParameters(),
-            $this->getMetaTags(),
-            $this->getLinkTags(),
+            $renderer->getCommonParameters(),
+            $renderer->getLayoutParameters(),
+            $renderer->getMetaTags(),
+            $renderer->getLinkTags(),
         );
     }
 
@@ -605,6 +611,32 @@ final class WebViewRenderer implements ViewContextInterface
     private function setViewPath(?string $path): void
     {
         $this->viewPath = $path === null ? null : rtrim($path, '/');
+    }
+
+    private function withDefaultViewPath(): self
+    {
+        if ($this->viewPath !== null) {
+            return $this;
+        }
+
+        $new = clone $this;
+        $new->setViewPath($this->getCallLocationViewPath());
+        return $new;
+    }
+
+    private function getCallLocationViewPath(): string
+    {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+            $file = $frame['file'] ?? __FILE__;
+
+            if ($file === __FILE__) {
+                continue;
+            }
+
+            return dirname($file);
+        }
+
+        throw new RuntimeException('Cannot detect view path.');
     }
 
     private function getPreparedInjections(): array

--- a/src/WebViewRenderer.php
+++ b/src/WebViewRenderer.php
@@ -51,6 +51,8 @@ use const DEBUG_BACKTRACE_IGNORE_ARGS;
  */
 final class WebViewRenderer implements ViewContextInterface
 {
+    private const CALL_LOCATION_BACKTRACE_LIMIT = 10;
+
     private ?string $viewPath = null;
     private ?string $name = null;
     private ?string $locale = null;
@@ -626,7 +628,9 @@ final class WebViewRenderer implements ViewContextInterface
 
     private function getCallLocationViewPath(): string
     {
-        return $this->resolveCallLocationViewPath(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10));
+        return $this->resolveCallLocationViewPath(
+            debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, self::CALL_LOCATION_BACKTRACE_LIMIT),
+        );
     }
 
     /**

--- a/tests/Debug/WebViewCollectorTest.php
+++ b/tests/Debug/WebViewCollectorTest.php
@@ -25,4 +25,23 @@ final class WebViewCollectorTest extends AbstractCollectorTestCase
     {
         return new WebViewCollector();
     }
+
+    protected function checkCollectedData(array $data): void
+    {
+        $this->assertSame(
+            [
+                [
+                    'output' => 'test content',
+                    'file' => __FILE__,
+                    'parameters' => ['foo' => 'bar'],
+                ],
+            ],
+            $data,
+        );
+    }
+
+    protected function checkSummaryData(array $data): void
+    {
+        $this->assertSame(['total' => 1], $data);
+    }
 }

--- a/tests/Support/Action/RelativeViewAction.php
+++ b/tests/Support/Action/RelativeViewAction.php
@@ -28,4 +28,9 @@ final class RelativeViewAction
     {
         return $renderer->renderPartialAsString('template', ['name' => 'renderPartialAsString']);
     }
+
+    public function renderNestedFromView(WebViewRenderer $renderer): string
+    {
+        return $renderer->renderAsString('nested-render', ['renderer' => $renderer]);
+    }
 }

--- a/tests/Support/Action/RelativeViewAction.php
+++ b/tests/Support/Action/RelativeViewAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\View\Renderer\Tests\Support\Action;
+
+use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Yii\View\Renderer\WebViewRenderer;
+
+final class RelativeViewAction
+{
+    public function render(WebViewRenderer $renderer): ResponseInterface
+    {
+        return $renderer->render('template', ['name' => 'render']);
+    }
+
+    public function renderPartial(WebViewRenderer $renderer): ResponseInterface
+    {
+        return $renderer->renderPartial('template', ['name' => 'renderPartial']);
+    }
+
+    public function renderAsString(WebViewRenderer $renderer): string
+    {
+        return $renderer->renderAsString('template', ['name' => 'renderAsString']);
+    }
+
+    public function renderPartialAsString(WebViewRenderer $renderer): string
+    {
+        return $renderer->renderPartialAsString('template', ['name' => 'renderPartialAsString']);
+    }
+}

--- a/tests/Support/Action/nested-render.php
+++ b/tests/Support/Action/nested-render.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Yii\View\Renderer\WebViewRenderer;
+
+/**
+ * @var WebViewRenderer $renderer
+ */
+
+echo 'Outer view. ' . $renderer->renderAsString('nested-template', ['name' => 'nested view']);

--- a/tests/Support/Action/nested-template.php
+++ b/tests/Support/Action/nested-template.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var string $name
+ */
+
+echo 'Nested from ' . $name;

--- a/tests/Support/Action/template.php
+++ b/tests/Support/Action/template.php
@@ -1,0 +1,1 @@
+Action view: <?= $name ?>

--- a/tests/Support/Action/template.php
+++ b/tests/Support/Action/template.php
@@ -1,1 +1,9 @@
-Action view: <?= $name ?>
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var string $name
+ */
+
+echo 'Action view: ' . $name;

--- a/tests/ViewRendererTest.php
+++ b/tests/ViewRendererTest.php
@@ -17,10 +17,12 @@ use Yiisoft\DataResponse\DataResponseFactory;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
 use Yiisoft\View\WebView;
+use Yiisoft\Yii\View\Renderer\CommonParametersInjectionInterface;
 use Yiisoft\Yii\View\Renderer\Exception\InvalidLinkTagException;
 use Yiisoft\Yii\View\Renderer\Exception\InvalidMetaTagException;
 use Yiisoft\Yii\View\Renderer\InjectionContainer\InjectionContainer;
 use Yiisoft\Yii\View\Renderer\InjectionContainer\InjectionContainerInterface;
+use Yiisoft\Yii\View\Renderer\LayoutParametersInjectionInterface;
 use Yiisoft\Yii\View\Renderer\LayoutSpecificInjections;
 use Yiisoft\Yii\View\Renderer\MetaTagsInjectionInterface;
 use Yiisoft\Yii\View\Renderer\Tests\Support\CharsetInjection;
@@ -186,6 +188,16 @@ EOD;
             ->render('locale');
 
         $this->assertSame('<html><body>de_DE locale</body></html>', (string) $response->getBody());
+    }
+
+    public function testWithLocaleDoesNotMutateOriginalRenderer(): void
+    {
+        $renderer = $this->getRenderer()
+            ->withInjections(new TestInjection());
+        $localizedRenderer = $renderer->withLocale('de_DE');
+
+        $this->assertSame('<html><body>de_DE locale</body></html>', (string) $localizedRenderer->render('locale')->getBody());
+        $this->assertSame('<html><body>not localized</body></html>', (string) $renderer->render('locale')->getBody());
     }
 
     public static function dataWithController(): array
@@ -511,6 +523,33 @@ EOD;
         $this->assertEqualStringsIgnoringLineEndings($expected, (string) $response->getBody());
     }
 
+    public function testLazyLoadingInjectionIsPreparedOnce(): void
+    {
+        $container = new class implements InjectionContainerInterface {
+            private int $count = 0;
+
+            public function get(string $id): object
+            {
+                return new class (++$this->count) implements CommonParametersInjectionInterface {
+                    public function __construct(private readonly int $number) {}
+
+                    public function getCommonParameters(): array
+                    {
+                        return ['name' => 'name-' . $this->number];
+                    }
+                };
+            }
+        };
+
+        $renderer = $this
+            ->getRenderer(injectionContainer: $container)
+            ->withLayout(null)
+            ->withInjections('dynamic-name');
+
+        $this->assertSame('<b>name-1</b>', (string) $renderer->render('simple')->getBody());
+        $this->assertSame('<b>name-1</b>', (string) $renderer->render('simple')->getBody());
+    }
+
     public function testLazyLoadingInjectionWithoutContainer(): void
     {
         $renderer = $this
@@ -552,6 +591,49 @@ EOD;
 
         $this->assertSame(
             '<html><head><title>Hello</title><meta charset="windows-1251"></head><body><h1>Hello</h1></body></html>',
+            (string) $response->getBody(),
+        );
+    }
+
+    public function testWithAddedInjectionsKeepsExistingInjections(): void
+    {
+        $renderer = $this
+            ->getRenderer()
+            ->withLayout(null)
+            ->withInjections(new TestInjection())
+            ->withAddedInjections(
+                new class implements CommonParametersInjectionInterface {
+                    public function getCommonParameters(): array
+                    {
+                        return ['species' => 'turtle'];
+                    }
+                },
+            );
+
+        $response = $renderer->render('parameters');
+
+        $this->assertSame('leonardo/turtle', (string) $response->getBody());
+    }
+
+    public function testDirectInjectionDoesNotSkipFollowingLayoutSpecificInjection(): void
+    {
+        $renderer = $this
+            ->getRenderer()
+            ->withLayout('@views/nested-layout/layout.php')
+            ->withInjections(
+                new class implements LayoutParametersInjectionInterface {
+                    public function getLayoutParameters(): array
+                    {
+                        return ['title' => 'Direct'];
+                    }
+                },
+                new LayoutSpecificInjections('@views/nested-layout/layout.php', new TitleInjection()),
+            );
+
+        $response = $renderer->render('empty');
+
+        $this->assertSame(
+            '<html><head><title>Hello</title></head><body><h1>Hello</h1></body></html>',
             (string) $response->getBody(),
         );
     }

--- a/tests/WebViewRendererTest.php
+++ b/tests/WebViewRendererTest.php
@@ -9,6 +9,7 @@ use HttpSoft\Message\StreamFactory;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use ReflectionObject;
 use RuntimeException;
 use stdClass;
@@ -524,8 +525,54 @@ EOD;
         );
         $method->invoke($renderer, [
             [],
+            ['file' => 42],
             ['file' => dirname(__DIR__) . '/src/WebViewRenderer.php'],
         ]);
+    }
+
+    public function testCallLocationViewPathDetectionSkipsInvalidFrames(): void
+    {
+        $renderer = new WebViewRenderer(
+            new ResponseFactory(),
+            new StreamFactory(),
+            new Aliases(),
+            new WebView(__DIR__, new SimpleEventDispatcher()),
+        );
+
+        $method = (new ReflectionObject($renderer))->getMethod('resolveCallLocationViewPath');
+        $method->setAccessible(true);
+
+        $this->assertSame(
+            __DIR__ . '/Support/Action',
+            $method->invoke($renderer, [
+                [],
+                ['file' => 42],
+                ['file' => __DIR__ . '/Support/Action/RelativeViewAction.php'],
+            ]),
+        );
+    }
+
+    public function testRenderWithDefaultViewPathDoesNotMutateRenderer(): void
+    {
+        $renderer = new WebViewRenderer(
+            new ResponseFactory(),
+            new StreamFactory(),
+            new Aliases(),
+            new WebView(__DIR__, new SimpleEventDispatcher()),
+        );
+
+        (new RelativeViewAction())->renderAsString($renderer);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The view path is not set.');
+        $renderer->getViewPath();
+    }
+
+    public function testCallLocationBacktraceLimit(): void
+    {
+        $reflection = new ReflectionClass(WebViewRenderer::class);
+
+        $this->assertSame(10, $reflection->getConstant('CALL_LOCATION_BACKTRACE_LIMIT'));
     }
 
     public function testLazyLoadingInjection(): void

--- a/tests/WebViewRendererTest.php
+++ b/tests/WebViewRendererTest.php
@@ -37,6 +37,8 @@ use Yiisoft\Yii\View\Renderer\Tests\Support\TitleInjection;
 use Yiisoft\Yii\View\Renderer\WebViewRenderer;
 use Fake8Controller;
 
+use function dirname;
+
 final class WebViewRendererTest extends TestCase
 {
     use TestTrait;
@@ -502,6 +504,28 @@ EOD;
         $this->assertSame('Action view: renderPartial', (string) $action->renderPartial($renderer)->getBody());
         $this->assertSame('Action view: renderAsString', $action->renderAsString($renderer));
         $this->assertSame('Action view: renderPartialAsString', $action->renderPartialAsString($renderer));
+    }
+
+    public function testCallLocationViewPathDetectionFailure(): void
+    {
+        $renderer = new WebViewRenderer(
+            new ResponseFactory(),
+            new StreamFactory(),
+            new Aliases(),
+            new WebView(__DIR__, new SimpleEventDispatcher()),
+        );
+
+        $method = (new ReflectionObject($renderer))->getMethod('resolveCallLocationViewPath');
+        $method->setAccessible(true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Cannot detect view path from call stack. Configure view path explicitly.',
+        );
+        $method->invoke($renderer, [
+            [],
+            ['file' => dirname(__DIR__) . '/src/WebViewRenderer.php'],
+        ]);
     }
 
     public function testLazyLoadingInjection(): void

--- a/tests/WebViewRendererTest.php
+++ b/tests/WebViewRendererTest.php
@@ -17,10 +17,12 @@ use Yiisoft\Aliases\Aliases;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
 use Yiisoft\View\WebView;
+use Yiisoft\Yii\View\Renderer\CommonParametersInjectionInterface;
 use Yiisoft\Yii\View\Renderer\Exception\InvalidLinkTagException;
 use Yiisoft\Yii\View\Renderer\Exception\InvalidMetaTagException;
 use Yiisoft\Yii\View\Renderer\InjectionContainer\InjectionContainer;
 use Yiisoft\Yii\View\Renderer\InjectionContainer\InjectionContainerInterface;
+use Yiisoft\Yii\View\Renderer\LayoutParametersInjectionInterface;
 use Yiisoft\Yii\View\Renderer\LayoutSpecificInjections;
 use Yiisoft\Yii\View\Renderer\MetaTagsInjectionInterface;
 use Yiisoft\Yii\View\Renderer\Tests\Support\Action\RelativeViewAction;
@@ -37,8 +39,6 @@ use Yiisoft\Yii\View\Renderer\Tests\Support\TestTrait;
 use Yiisoft\Yii\View\Renderer\Tests\Support\TitleInjection;
 use Yiisoft\Yii\View\Renderer\WebViewRenderer;
 use Fake8Controller;
-
-use function dirname;
 
 final class WebViewRendererTest extends TestCase
 {
@@ -189,6 +189,16 @@ EOD;
             ->render('locale');
 
         $this->assertSame('<html><body>de_DE locale</body></html>', (string) $response->getBody());
+    }
+
+    public function testWithLocaleDoesNotMutateOriginalRenderer(): void
+    {
+        $renderer = $this->getRenderer()
+            ->withInjections(new TestInjection());
+        $localizedRenderer = $renderer->withLocale('de_DE');
+
+        $this->assertSame('<html><body>de_DE locale</body></html>', (string) $localizedRenderer->render('locale')->getBody());
+        $this->assertSame('<html><body>not localized</body></html>', (string) $renderer->render('locale')->getBody());
     }
 
     public static function dataWithController(): array
@@ -526,7 +536,7 @@ EOD;
         $method->invoke($renderer, [
             [],
             ['file' => 42],
-            ['file' => dirname(__DIR__) . '/src/WebViewRenderer.php'],
+            ['file' => (new ReflectionClass(WebViewRenderer::class))->getFileName()],
         ]);
     }
 
@@ -600,6 +610,33 @@ EOD;
         $this->assertEqualStringsIgnoringLineEndings($expected, (string) $response->getBody());
     }
 
+    public function testLazyLoadingInjectionIsPreparedOnce(): void
+    {
+        $container = new class implements InjectionContainerInterface {
+            private int $count = 0;
+
+            public function get(string $id): object
+            {
+                return new class (++$this->count) implements CommonParametersInjectionInterface {
+                    public function __construct(private readonly int $number) {}
+
+                    public function getCommonParameters(): array
+                    {
+                        return ['name' => 'name-' . $this->number];
+                    }
+                };
+            }
+        };
+
+        $renderer = $this
+            ->getRenderer(injectionContainer: $container)
+            ->withLayout(null)
+            ->withInjections('dynamic-name');
+
+        $this->assertSame('<b>name-1</b>', (string) $renderer->render('simple')->getBody());
+        $this->assertSame('<b>name-1</b>', (string) $renderer->render('simple')->getBody());
+    }
+
     public function testLazyLoadingInjectionWithoutContainer(): void
     {
         $renderer = $this
@@ -641,6 +678,49 @@ EOD;
 
         $this->assertSame(
             '<html><head><title>Hello</title><meta charset="windows-1251"></head><body><h1>Hello</h1></body></html>',
+            (string) $response->getBody(),
+        );
+    }
+
+    public function testWithAddedInjectionsKeepsExistingInjections(): void
+    {
+        $renderer = $this
+            ->getRenderer()
+            ->withLayout(null)
+            ->withInjections(new TestInjection())
+            ->withAddedInjections(
+                new class implements CommonParametersInjectionInterface {
+                    public function getCommonParameters(): array
+                    {
+                        return ['species' => 'turtle'];
+                    }
+                },
+            );
+
+        $response = $renderer->render('parameters');
+
+        $this->assertSame('leonardo/turtle', (string) $response->getBody());
+    }
+
+    public function testDirectInjectionDoesNotSkipFollowingLayoutSpecificInjection(): void
+    {
+        $renderer = $this
+            ->getRenderer()
+            ->withLayout('@views/nested-layout/layout.php')
+            ->withInjections(
+                new class implements LayoutParametersInjectionInterface {
+                    public function getLayoutParameters(): array
+                    {
+                        return ['title' => 'Direct'];
+                    }
+                },
+                new LayoutSpecificInjections('@views/nested-layout/layout.php', new TitleInjection()),
+            );
+
+        $response = $renderer->render('empty');
+
+        $this->assertSame(
+            '<html><head><title>Hello</title></head><body><h1>Hello</h1></body></html>',
             (string) $response->getBody(),
         );
     }

--- a/tests/WebViewRendererTest.php
+++ b/tests/WebViewRendererTest.php
@@ -22,6 +22,7 @@ use Yiisoft\Yii\View\Renderer\InjectionContainer\InjectionContainer;
 use Yiisoft\Yii\View\Renderer\InjectionContainer\InjectionContainerInterface;
 use Yiisoft\Yii\View\Renderer\LayoutSpecificInjections;
 use Yiisoft\Yii\View\Renderer\MetaTagsInjectionInterface;
+use Yiisoft\Yii\View\Renderer\Tests\Support\Action\RelativeViewAction;
 use Yiisoft\Yii\View\Renderer\Tests\Support\CharsetInjection;
 use Yiisoft\Yii\View\Renderer\Tests\Support\FakeCntrl;
 use Yiisoft\Yii\View\Renderer\Tests\Support\FakeController;
@@ -484,6 +485,23 @@ EOD;
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The view path is not set.');
         $viewRenderer->getViewPath();
+    }
+
+    public function testRenderUsesCallLocationAsViewPathWhenViewPathIsNull(): void
+    {
+        $renderer = new WebViewRenderer(
+            new ResponseFactory(),
+            new StreamFactory(),
+            new Aliases(),
+            new WebView(__DIR__, new SimpleEventDispatcher()),
+        );
+
+        $action = new RelativeViewAction();
+
+        $this->assertSame('Action view: render', (string) $action->render($renderer)->getBody());
+        $this->assertSame('Action view: renderPartial', (string) $action->renderPartial($renderer)->getBody());
+        $this->assertSame('Action view: renderAsString', $action->renderAsString($renderer));
+        $this->assertSame('Action view: renderPartialAsString', $action->renderPartialAsString($renderer));
     }
 
     public function testLazyLoadingInjection(): void

--- a/tests/WebViewRendererTest.php
+++ b/tests/WebViewRendererTest.php
@@ -515,6 +515,7 @@ EOD;
         $this->assertSame('Action view: renderPartial', (string) $action->renderPartial($renderer)->getBody());
         $this->assertSame('Action view: renderAsString', $action->renderAsString($renderer));
         $this->assertSame('Action view: renderPartialAsString', $action->renderPartialAsString($renderer));
+        $this->assertSame('Outer view. Nested from nested view', $action->renderNestedFromView($renderer));
     }
 
     public function testCallLocationViewPathDetectionFailure(): void

--- a/tests/views/parameters.php
+++ b/tests/views/parameters.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var string $name
+ * @var string $species
+ */
+
+echo $name . '/' . $species;


### PR DESCRIPTION
## Summary
- Resolve WebViewRenderer relative view paths from the render call location when viewPath is null
- Preserve the resolved call location for deferred ViewResponse rendering
- Add action-style coverage for render(), renderPartial(), renderAsString(), and renderPartialAsString()

Fixes #151